### PR TITLE
Fix Lore format and add Deepslate Variants to Mining mastery

### DIFF
--- a/src/main/resources/guis/en/selector.yml
+++ b/src/main/resources/guis/en/selector.yml
@@ -10,25 +10,25 @@ options:
       # Ignore this, it doesn't do anything.
       DIAMOND_SWORD: "%skills_level% > 5"
       IRON_SWORD: "%skills_level% <= 5"
-    lore: |-
-      &3Swordsmen are the prime of all melee
-      battles, with superior damage
-      and close-range capabilities.
-
-      &e&lStrength
-      &2Swordsmen are strong in
-      one on one battles,
-      and can win most other
-      skills if fought well.
-
-      &e&lWeakness
-      &cSwordsmen don't have powerful ranged
-      capabilities, and can be outmatched
-      by ranged attacks.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Swordsmen are the prime of all melee,"
+      - "&3battles, with superior damage"
+      - "&3and close-range capabilities."
+      - ""
+      - "&e&lStrength"
+      - "&2Swordsmen are strong in"
+      - "&2one on one battles,"
+      - "&2and can win most other"
+      - "&2skills if fought well."
+      - ""
+      - "&e&lWeakness"
+      - "&cSwordsmen don't have powerful ranged"
+      - "&ccapabilities, and can be outmatched"
+      - "&cby ranged attacks."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ENTITY_PLAYER_ATTACK_CRIT
     flags: [ HIDE_ATTRIBUTES ]
     posx: 7
@@ -36,25 +36,25 @@ options:
   juggernaut:
     name: "&7Juggernaut"
     material: DIAMOND_CHESTPLATE
-    lore: |-
-      &3The most durable warriors,
-      juggernauts are powerful behemoths
-      that can soak up a lot of damage.
-
-      &e&lStrength
-      &2Very strong against non-healing skills,
-      as you can out last your opponent.
-
-      &e&lWeakness
-      &cVery low damage output.
-      Although you are durable, if you fail
-      to dish out enough damage to take out
-      your enemy before he takes you out,
-      you would be doomed.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3The most durable warriors,"
+      - "&3juggernauts are powerful behemoths"
+      - "&3that can soak up a lot of damage."
+      - ""
+      - "&e&lStrength"
+      - "&2Very strong against non-healing skills,"
+      - "&2as you can out last your opponent."
+      - ""
+      - "&e&lWeakness"
+      - "&cVery low damage output."
+      - "&cAlthough you are durable, if you fail"
+      - "&cto dish out enough damage to take out"
+      - "&cyour enemy before he takes you out,"
+      - "&cyou would be doomed."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: BLOCK_ANVIL_PLACE
     flags: [ HIDE_ATTRIBUTES ]
     posx: 6
@@ -62,23 +62,24 @@ options:
   mage:
     name: "&dMage"
     material: GOLDEN_HOE
-    lore: |-
-      &3Mages are masters of offensive
-      and defensive magic,
-      and battle with Staffs to cast
-      spells and curses on their enemies.
-      &e&lStrength
-      &2Mages can counter many skill
-      types as their attacks with
-      Staffs can cause different
-      attacks to occur.
-      &e&lWeakness
-      &cMages rely on Mana,
-      and are severely weakened without it.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Mages are masters of offensive"
+      - "&3and defensive magic,"
+      - "&3and battle with Staffs to cast"
+      - "&3spells and curses on their enemies."
+      - ""
+      - "&e&lStrength"
+      - "&2Mages can counter many skill"
+      - "&2types as their attacks with"
+      - "&2staffs can cause different"
+      - "&2attacks to occur."
+      - "&e&lWeakness"
+      - "&cMages rely on Mana,"
+      - "&cand are severely weakened without it."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ITEM_FLINTANDSTEEL_USE
     flags: [ HIDE_ATTRIBUTES ]
     posx: 5
@@ -86,53 +87,53 @@ options:
   firemage:
     name: "&cFire Mage"
     material: BLAZE_POWDER
-    lore: |-
-      &3FireMages, unlike Mages,
-      are fully focused on
-      fire-based offensive spells,
-      and don't use staffs.
-      They cast spells by
-      expending their own health.
-
-      &e&lStrength
-      &2While health is spent on spells,
-      the spells can deliver devastating
-      blows to your foes.
-
-      &e&lWeakness
-      &cFireMages are weak against
-      fire-resistance potions.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3FireMages, unlike Mages,"
+      - "&3are fully focused on"
+      - "&3fire-based offensive spells,"
+      - "&3and don't use staffs."
+      - "&3they cast spells by"
+      - "&3expending their own health."
+      - ""
+      - "&e&lStrength"
+      - "&2While health is spent on spells,"
+      - "&2the spells can deliver devastating"
+      - "&2slows to your foes."
+      - ""
+      - "&e&lWeakness"
+      - "&cFireMages are weak against"
+      - "&cfire-resistance potions."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ITEM_FIRECHARGE_USE
     posx: 4
     posy: 3
   arbalist:
     name: "&5Arbalist"
     material: BOW
-    lore: |-
-      &3Arbalists are adaptive,
-      with different playstyles,
-      up front battle, and sniping from afar.
-      Arbalists utilize Crossbows to fight.
-
-      &e&lStrength
-      &2Arbalists can deal a lot of damage,
-      if the target fails to reach the
-      arbalist in time, and also have
-      a lot of knockback capabilities.
-
-      &e&lWeakness
-      &cArbalists are weak in
-      short range combat,
-      and only rely on knockback to
-      keep their enemies at bay.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Arbalists are adaptive,"
+      - "&3with different playstyles,"
+      - "&3up front battle, and sniping from afar."
+      - "&3Arbalists utilize Crossbows to fight."
+      - ""
+      - "&e&lStrength"
+      - "&2Arbalists can deal a lot of damage,"
+      - "&2if the target fails to reach the"
+      - "&2arbalist in time, and also have"
+      - "&2a lot of knockback capabilities."
+      - ""
+      - "&e&lWeakness"
+      - "&cArbalists are weak in"
+      - "&cshort range combat,"
+      - "&cand only rely on knockback to"
+      - "&ckeep their enemies at bay."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ENTITY_ARROW_SHOOT
     flags: [ HIDE_ATTRIBUTES ]
     posx: 3
@@ -140,96 +141,96 @@ options:
   vampire:
     name: "&4Vampire"
     material: REDSTONE
-    lore: |-
-      &3Vampires are majestic
-      yet horrible demons,
-      with the uncanny abilities
-      of regeneration and stealth.
-
-      &e&lStrength
-      &2Attacks can deplete your opponent of Mana,
-      and you also have many healing
-      abilities of your own.
-
-      &e&lWeakness
-      &cVampires are all rounded,
-      but can be outpaced by
-      targets with high mobility.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Vampires are majestic"
+      - "&3yet horrible demons,"
+      - "&3with the uncanny abilities"
+      - "&3of regeneration and stealth."
+      - ""
+      - "&e&lStrength"
+      - "&2Attacks can deplete your opponent of Mana,"
+      - "&2and you also have many healing"
+      - "&2abilities of your own."
+      - ""
+      - "&e&lWeakness"
+      - "&cVampires are all rounded,"
+      - "&cbut can be outpaced by"
+      - "&ctargets with high mobility."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ENTITY_BAT_AMBIENT
     posx: 3
     posy: 4
   priest:
     name: "&2Priest"
     material: KNOWLEDGE_BOOK
-    lore: |-
-      &3Priests are mainly supporters
-      that can play a huge role in a team.
-      They also have a few extra
-      abilities for survival.
-
-      &e&lStrength
-      &2Priests are mostly defensive.
-      Both for them and their team.
-
-      &e&lWeakness
-      &cPriests are vulnerable to unholiness.
-      Such as nether and the end
-      and creatures like Wither.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Priests are mainly supporters"
+      - "&3hat can play a huge role in a team."
+      - "&3hey also have a few extra"
+      - "&3bilities for survival."
+      - ""
+      - "&e&lStrength"
+      - "&2Priests are mostly defensive."
+      - "&2both for them and their team."
+      - ""
+      - "&e&lWeakness"
+      - "&cPriests are vulnerable to unholiness."
+      - "&csuch as nether and the end"
+      - "&cand creatures like Wither."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: BLOCK_ENCHANTMENT_TABLE_USE
     posx: 4
     posy: 4
   devourer:
     name: "&9Devourer"
     material: SPIDER_EYE
-    lore: |-
-      &3Devourers are fast, agile, and
-      their strikes are very corrosive.
-      Hit-and-run specialists.
-
-      &e&lStrength
-      &2Nothing can outrun a devourer,
-      as they have powerful techniques to
-      get away from danger,
-      and an equally corrosive strike.
-
-      &e&lWeakness
-      &cDevourers have weak defensive capability.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Devourers are fast, agile, and"
+      - "&3their strikes are very corrosive."
+      - "&3Hit-and-run specialists."
+      - ""
+      - "&e&lStrength"
+      - "&2Nothing can outrun a devourer,"
+      - "&2as they have powerful techniques to"
+      - "&2get away from danger,"
+      - "&2and an equally corrosive strike."
+      - ""
+      - "&e&lWeakness"
+      - "&cDevourers have weak defensive capability."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ENTITY_ENDERMITE_AMBIENT
     posx: 6
     posy: 4
   eidolon:
     name: "&3Eidolon"
     material: END_CRYSTAL
-    lore: |-
-      &3Eidolons are spirits, that periodically
-      change form, switching
-      between Dark and Light.
-
-      &e&lStrength
-      &2Eidolon has both defensive and offensive
-      abilities, and if used wisely,
-      can be a very effective melee fighter.
-
-      &e&lWeakness
-      &cOffensive abilites are mostly in
-      Eidolon's Dark form, and vice versa.
-      Complex to master.
-
-      &3Required Level&8: &e%required-level%
-      &3Level&8: &e%level%
-      &3Cost&8: &e%cost%
+    lore:
+      - "&3Eidolons are spirits, that periodically"
+      - "&3change form, switching"
+      - "&3between Dark and Light."
+      - ""
+      - "&e&lStrength"
+      - "&2Eidolon has both defensive and offensive"
+      - "&2abilities, and if used wisely,"
+      - "&2can be a very effective melee fighter."
+      - ""
+      - "&e&lWeakness"
+      - "&cOffensive abilites are mostly in"
+      - "&cEidolon's Dark form, and vice versa."
+      - "&ccomplex to master."
+      - ""
+      - "&3Required Level&8: &e%required-level%"
+      - "&3Level&8: &e%level%"
+      - "&3Cost&8: &e%cost%"
     sound: ENTITY_ENDERMAN_SCREAM
     posx: 7
     posy: 4

--- a/src/main/resources/masteries.yml
+++ b/src/main/resources/masteries.yml
@@ -69,6 +69,15 @@ masteries:
     # XP is the skills XP and EXP is the vanilla XP.
     # They all support formulas.
     blocks:
+      DEEPSLATE_EMERALD_ORE:
+        chance: randInt(0, (lvl + 9) / 2)
+        xp: 2
+        exp: 10
+        souls: 0
+        drops:
+          diamond:
+            material: EMERALD
+            amount: randInt(1, (lvl + 9) / 3)
       EMERALD_ORE:
         chance: randInt(0, (lvl + 9) / 2)
         xp: 2
@@ -77,6 +86,15 @@ masteries:
         drops:
           diamond:
             material: EMERALD
+            amount: randInt(1, (lvl + 9) / 3)
+      DEEPSLATE_DIAMOND_ORE:
+        chance: randInt(0, lvl + 1)
+        xp: 2
+        exp: 4
+        souls: 0
+        drops:
+          diamond:
+            material: DIAMOND
             amount: randInt(1, (lvl + 9) / 3)
       DIAMOND_ORE:
         chance: randInt(0, lvl + 1)
@@ -87,6 +105,15 @@ masteries:
           diamond:
             material: DIAMOND
             amount: randInt(1, (lvl + 9) / 3)
+      DEEPSLATE_GOLD_ORE:
+        chance: randInt(0, lvl + 1)
+        xp: 2
+        exp: 4
+        souls: 0
+        drops:
+          diamond:
+            material: GOLD_INGOT
+            amount: randInt(1, (lvl + 9) / 3)
       GOLD_ORE:
         chance: randInt(0, lvl + 1)
         xp: 2
@@ -96,12 +123,25 @@ masteries:
           diamond:
             material: GOLD_INGOT
             amount: randInt(1, (lvl + 9) / 3)
+      DEEPSLATE_IRON_ORE:
+        chance: randInt(0, lvl + 1)
+        exp: 1
+        drops:
+          diamond:
+            material: IRON_INGOT
+            amount: randInt(1, (lvl + 9) / 3)
       IRON_ORE:
         chance: randInt(0, lvl + 1)
         exp: 1
         drops:
           diamond:
             material: IRON_INGOT
+            amount: randInt(1, (lvl + 9) / 3)
+      DEEPSLATE_COAL_ORE:
+        chance: randInt(0, lvl * 2)
+        drops:
+          diamond:
+            material: COAL
             amount: randInt(1, (lvl + 9) / 3)
       COAL_ORE:
         chance: randInt(0, lvl * 2)


### PR DESCRIPTION
Lore format was broken in /skills select previously and would appear like this:

![image](https://user-images.githubusercontent.com/30600688/173158297-a60e7f9a-6bf7-4802-bce0-1f735ce5fa83.png)

They should now appear like this:
![image](https://user-images.githubusercontent.com/30600688/173158349-1bfd572c-5fc6-478b-9c65-a98cf143decf.png)
